### PR TITLE
Rename description field in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Sample scenario definition file:
 
 ```yaml
 scenarios:
-  - description: curl metadata service
+  - name: curl metadata service
     detonate:
       remoteDetonator:
         commands: ["curl http://169.254.169.254 --connect-timeout 1"]
@@ -79,7 +79,7 @@ scenarios:
           name: "Network utility accessed cloud metadata service"
           severity: medium
 
-  - description: running nmap
+  - name: running nmap
     detonate:
       remoteDetonator:
         commands:


### PR DESCRIPTION
### What does this PR do?
Change `description` field to `name` in the README.

### Motivation
The field names were changed in https://github.com/DataDog/threatest/commit/aaf8c50798dedec8651fb885dae957bad21e1508.
