### PR TITLE
Schema change proposal for Atomic Red Team support

### DIFF
--- a/pkg/threatest/parser/main.go
+++ b/pkg/threatest/parser/main.go
@@ -2,12 +2,13 @@ package parser
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/datadog/threatest/pkg/threatest"
 	"github.com/datadog/threatest/pkg/threatest/detonators"
 	"github.com/datadog/threatest/pkg/threatest/matchers/datadog"
 	"sigs.k8s.io/yaml" // we use this library as it provides a handy "YAMLToJSON" function
-	"strings"
-	"time"
 )
 
 // Parse turns a YAML input string into a list of Threatest scenarios
@@ -42,9 +43,11 @@ func buildScenarios(parsed *ThreatestSchemaJson, sshHostname string, sshUsername
 
 		// Detonation
 		if localDetonator := parsedScenario.Detonate.LocalDetonator; localDetonator != nil {
+			// TODO: handle Atomic Red Team
 			commandToRun := strings.Join(parsedScenario.Detonate.LocalDetonator.Commands, "; ")
 			scenario.Detonator = detonators.NewCommandDetonator(&detonators.LocalCommandExecutor{}, commandToRun)
 		} else if remoteDetonator := parsedScenario.Detonate.RemoteDetonator; remoteDetonator != nil {
+			// TODO: handle Atomic Red Team
 			commandToRun := strings.Join(remoteDetonator.Commands, "; ")
 			//TODO: decouple
 			//TODO: confirm 1 SSH executor per attack makes sense

--- a/pkg/threatest/parser/parser.go
+++ b/pkg/threatest/parser/parser.go
@@ -5,23 +5,20 @@ package parser
 import "encoding/json"
 import "fmt"
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DatadogSecuritySignalSchemaJson) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DatadogSecuritySignalSchemaJson: required")
-	}
-	type Plain DatadogSecuritySignalSchemaJson
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DatadogSecuritySignalSchemaJson(plain)
-	return nil
+// Configuration of an Atomic Red Team test case
+type AtomicRedTeamSchemaJson struct {
+	// Inputs for the Atomic Red Team test case
+	Inputs AtomicRedTeamSchemaJsonInputs `json:"inputs,omitempty" yaml:"inputs,omitempty" mapstructure:"inputs,omitempty"`
+
+	// Atomic Red Team test case name
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// MITRE ATT&CK technique ID
+	Technique string `json:"technique" yaml:"technique" mapstructure:"technique"`
 }
+
+// Inputs for the Atomic Red Team test case
+type AtomicRedTeamSchemaJsonInputs map[string]string
 
 // Definition of an AWS CLI detonation
 type AwsCliDetonatorSchemaJson struct {
@@ -40,12 +37,18 @@ type DatadogSecuritySignalSchemaJson struct {
 
 // Definition of a local command detonation
 type LocalDetonatorSchemaJson struct {
+	// AtomicReadTeam corresponds to the JSON schema field "atomicReadTeam".
+	AtomicReadTeam *AtomicRedTeamSchemaJson `json:"atomicReadTeam,omitempty" yaml:"atomicReadTeam,omitempty" mapstructure:"atomicReadTeam,omitempty"`
+
 	// Commands corresponds to the JSON schema field "commands".
 	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" mapstructure:"commands,omitempty"`
 }
 
 // Definition of a remote command detonation
 type RemoteDetonatorSchemaJson struct {
+	// AtomicReadTeam corresponds to the JSON schema field "atomicReadTeam".
+	AtomicReadTeam *AtomicRedTeamSchemaJson `json:"atomicReadTeam,omitempty" yaml:"atomicReadTeam,omitempty" mapstructure:"atomicReadTeam,omitempty"`
+
 	// Commands corresponds to the JSON schema field "commands".
 	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" mapstructure:"commands,omitempty"`
 }
@@ -71,6 +74,45 @@ type ThreatestSchemaJsonScenariosElemDetonate struct {
 	// StratusRedTeamDetonator corresponds to the JSON schema field
 	// "stratusRedTeamDetonator".
 	StratusRedTeamDetonator *StratusRedTeamDetonatorSchemaJson `json:"stratusRedTeamDetonator,omitempty" yaml:"stratusRedTeamDetonator,omitempty" mapstructure:"stratusRedTeamDetonator,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *AtomicRedTeamSchemaJson) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in AtomicRedTeamSchemaJson: required")
+	}
+	if v, ok := raw["technique"]; !ok || v == nil {
+		return fmt.Errorf("field technique in AtomicRedTeamSchemaJson: required")
+	}
+	type Plain AtomicRedTeamSchemaJson
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = AtomicRedTeamSchemaJson(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DatadogSecuritySignalSchemaJson) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DatadogSecuritySignalSchemaJson: required")
+	}
+	type Plain DatadogSecuritySignalSchemaJson
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DatadogSecuritySignalSchemaJson(plain)
+	return nil
 }
 
 // Expectations

--- a/schemas/atomicRedTeam.schema.json
+++ b/schemas/atomicRedTeam.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/datadog/threatest/atomicRedTeam.schema.json",
+    "description": "Configuration of an Atomic Red Team test case",
+    "type": "object",
+    "required": [
+        "technique",
+        "name"
+    ],
+    "properties": {
+        "technique": {
+            "type": "string",
+            "description": "MITRE ATT&CK technique ID"
+        },
+        "name": {
+            "type": "string",
+            "description": "Atomic Red Team test case name"
+        },
+        "inputs": {
+            "type": "object",
+            "description": "Inputs for the Atomic Red Team test case",
+            "additionalProperties": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/schemas/localDetonator.schema.json
+++ b/schemas/localDetonator.schema.json
@@ -1,10 +1,27 @@
 {
   "type": "object",
   "description": "Definition of a local command detonation",
+  "oneOf": [
+    {
+      "required": [
+        "commands"
+      ]
+    },
+    {
+      "required": [
+        "atomicRedTeam"
+      ]
+    }
+  ],
   "properties": {
     "commands": {
       "type": "array",
-      "items": {"type":  "string"}
+      "items": {
+        "type": "string"
+      }
+    },
+    "atomicReadTeam": {
+      "$ref": "atomicRedTeam.schema.json"
     }
   }
 }

--- a/schemas/remoteDetonator.schema.json
+++ b/schemas/remoteDetonator.schema.json
@@ -1,10 +1,27 @@
 {
   "type": "object",
   "description": "Definition of a remote command detonation",
+  "oneOf": [
+    {
+      "required": [
+        "commands"
+      ]
+    },
+    {
+      "required": [
+        "atomicRedTeam"
+      ]
+    }
+  ],
   "properties": {
     "commands": {
       "type": "array",
-      "items": {"type":  "string"}
+      "items": {
+        "type": "string"
+      }
+    },
+    "atomicReadTeam": {
+      "$ref": "atomicRedTeam.schema.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add support for Atomic Red Team into threatest.

### Motivation
Atomic Red team supports multiple host based attacks that are often simply bash commands.

This PR proposes to extend the local and remote detonators configurations to support atomic red team in addition to arbitrary commands.

### Checklist

<!--
For new features
-->
- [ ] Unit tests
- [ ] Documentation
