### PR TITLE
matchers(datadog) - Add WithCredentials option for explicit Datadog API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ threatest := Threatest()
 
 threatest.Scenario("AWS console login").
   WhenDetonating(StratusRedTeamTechnique("aws.initial-access.console-login-without-mfa")).
-  Expect(DatadogSecuritySignal("AWS Console login without MFA").WithSeverity("medium")).
+  Expect(DatadogSecuritySignal("AWS Console login without MFA", WithSeverity("medium"))).
   WithTimeout(15 * time.Minute)
 
 assert.NoError(t, threatest.Run())

--- a/examples/programmatic-usage/cloudsiem_alerts_test.go
+++ b/examples/programmatic-usage/cloudsiem_alerts_test.go
@@ -17,7 +17,7 @@ func TestCloudSIEMAWSAlerts(t *testing.T) {
 
 	threatest.Scenario("AWS console login").
 		WhenDetonating(StratusRedTeamTechnique("aws.initial-access.console-login-without-mfa")).
-		Expect(DatadogSecuritySignal("AWS Console login without MFA").WithSeverity("medium")).
+		Expect(DatadogSecuritySignal("AWS Console login without MFA", WithSeverity("medium"))).
 		WithTimeout(10 * time.Minute)
 
 	threatest.Scenario("Opening port 22 of a security group to the Internet").

--- a/pkg/threatest/matchers/datadog/types.go
+++ b/pkg/threatest/matchers/datadog/types.go
@@ -19,9 +19,29 @@ type DatadogAlertGeneratedAssertion struct {
 	AlertFilter *DatadogAlertFilter
 }
 
-// builder
+// DatadogAlertGeneratedAssertionBuilder constructs a DatadogAlertGeneratedAssertion
+// using the builder pattern.
 type DatadogAlertGeneratedAssertionBuilder struct {
 	DatadogAlertGeneratedAssertion
+}
+
+// Option configures a DatadogAlertGeneratedAssertionBuilder.
+type Option func(*DatadogAlertGeneratedAssertionBuilder)
+
+// WithCredentials overrides the default environment-variable-based
+// credentials (DD_API_KEY, DD_APP_KEY, DD_SITE) with explicit values.
+// This is useful when querying signals across multiple Datadog orgs.
+func WithCredentials(apiKey, appKey, site string) Option {
+	return func(b *DatadogAlertGeneratedAssertionBuilder) {
+		b.SignalsAPI = newSignalsAPI(apiKey, appKey, site)
+	}
+}
+
+// WithSeverity filters signals by severity (e.g. "medium", "high").
+func WithSeverity(severity string) Option {
+	return func(b *DatadogAlertGeneratedAssertionBuilder) {
+		b.AlertFilter.Severity = severity
+	}
 }
 
 func GetDDSite() string {
@@ -31,28 +51,45 @@ func GetDDSite() string {
 	return "datadoghq.com"
 }
 
-func DatadogSecuritySignal(name string) *DatadogAlertGeneratedAssertionBuilder {
-	builder := &DatadogAlertGeneratedAssertionBuilder{}
-	ddApiKey := os.Getenv("DD_API_KEY")
-	ddAppKey := os.Getenv("DD_APP_KEY")
+// newSignalsAPI creates a DatadogSecuritySignalsAPI with explicit credentials.
+func newSignalsAPI(apiKey, appKey, site string) DatadogSecuritySignalsAPI {
 	ctx := context.WithValue(context.Background(), datadog.ContextAPIKeys, map[string]datadog.APIKey{
-		"apiKeyAuth": {Key: ddApiKey},
-		"appKeyAuth": {Key: ddAppKey},
+		"apiKeyAuth": {Key: apiKey},
+		"appKeyAuth": {Key: appKey},
 	})
 	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
-		"site": GetDDSite(),
+		"site": site,
 	})
 	cfg := datadog.NewConfiguration()
 	cfg.SetUnstableOperationEnabled("SearchSecurityMonitoringSignals", true)
 
-	builder.SignalsAPI = &DatadogSecuritySignalsAPIImpl{
+	return &DatadogSecuritySignalsAPIImpl{
 		securityMonitoringAPI: datadogV2.NewSecurityMonitoringApi(datadog.NewAPIClient(cfg)),
 		ctx:                   ctx,
 	}
+}
+
+// DatadogSecuritySignal creates a builder for matching Datadog security
+// signals by rule name. By default, credentials are read from DD_API_KEY,
+// DD_APP_KEY, and DD_SITE environment variables. Use WithCredentials to
+// override.
+func DatadogSecuritySignal(name string, opts ...Option) *DatadogAlertGeneratedAssertionBuilder {
+	builder := &DatadogAlertGeneratedAssertionBuilder{}
+	builder.SignalsAPI = newSignalsAPI(
+		os.Getenv("DD_API_KEY"),
+		os.Getenv("DD_APP_KEY"),
+		GetDDSite(),
+	)
 	builder.AlertFilter = &DatadogAlertFilter{RuleName: name}
+
+	for _, opt := range opts {
+		opt(builder)
+	}
+
 	return builder
 }
 
+// Deprecated: Use WithSeverity option instead.
 func (m *DatadogAlertGeneratedAssertionBuilder) WithSeverity(severity string) *DatadogAlertGeneratedAssertionBuilder {
 	m.AlertFilter.Severity = severity
 	return m

--- a/pkg/threatest/parser/main.go
+++ b/pkg/threatest/parser/main.go
@@ -65,10 +65,11 @@ func buildScenarios(parsed *ThreatestSchemaJson, sshHostname string, sshUsername
 		}
 		for _, parsedAssertion := range parsedScenario.Expectations {
 			if datadogMatcher := parsedAssertion.DatadogSecuritySignal; datadogMatcher != nil {
-				assertion := datadog.DatadogSecuritySignal(datadogMatcher.Name)
+				var opts []datadog.Option
 				if severity := datadogMatcher.Severity; severity != nil {
-					assertion.WithSeverity(*severity)
+					opts = append(opts, datadog.WithSeverity(*severity))
 				}
+				assertion := datadog.DatadogSecuritySignal(datadogMatcher.Name, opts...)
 				scenario.Assertions = append(scenario.Assertions, assertion)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

<!--
* Bug fix
* Enhancement
* New detonator
* New matcher
-->

Enhancement: allows to pass the datadog credentials directly rather than using the env vars

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

When using programmatically, it can happen that we want threatest to interact with different datadog accounts. In that case, we need one pair of app/api keys per account.

goroutines [share the env variables](https://go.dev/play/p/Cl-vyfIVp9J) so we can't rely on that if we have mulitple parallel attacks for instance

### Checklist

<!--
For new features
-->
- [x] Unit tests
- [ ] Documentation
