### PR TITLE
ci(release) - Add dd-octo-sts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default code owners for all files in the repository
+# These owners will be requested for review when someone opens a pull request.
+
+* @DataDog/security-advocacy @DataDog/ase

--- a/.github/chainguard/self.release.create-pr.sts.yaml
+++ b/.github/chainguard/self.release.create-pr.sts.yaml
@@ -1,0 +1,16 @@
+# Policy for: .github/workflows/release.yml (goreleaser job) in DataDog/threatest
+# Grants contents:write for creating GitHub releases and pull_requests:write
+# for goreleaser to open homebrew formula update PRs.
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: repo:DataDog/threatest:ref:refs/tags/v.*
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/threatest/.github/workflows/release.yml@refs/tags/v.*
+  ref: refs/tags/v.*
+  repository: DataDog/threatest
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,30 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
+      contents: read
     steps:
+      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/threatest
+          policy: self.release.create-pr
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+      - name: Check if tag is on main branch
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag does not reference a commit on main branch"
+            exit 1
+          fi
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
@@ -30,4 +41,4 @@ jobs:
           version: "~> v2"
           args: release --clean --config .goreleaser.yaml
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,13 @@ brews:
     repository:
       owner: datadog
       name: threatest
+      branch: "homebrew-update-{{ .Version }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: datadog
+          name: threatest
+          branch: main
     directory: Formula
     url_template: "https://github.com/DataDog/threatest/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     license: Apache-2.0


### PR DESCRIPTION
### What does this PR do?

<!--
* Bug fix
* Enhancement
* New detonator
* New matcher
-->

- Add the dd-octo-sts action to retreive short lived gh tokens
- open a PR instead of pushing on main directly. Will require someone to manually merge (like in stratus red team)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix release process. It's annoying because I can only test by triggering a release so the fix are incremental 🫠 