### PR TITLE
Add error handling instead of panic on nil

### DIFF
--- a/pkg/threatest/parser/main.go
+++ b/pkg/threatest/parser/main.go
@@ -54,8 +54,14 @@ func buildScenarios(parsed *ThreatestSchemaJson, sshHostname string, sshUsername
 			}
 			scenario.Detonator = detonators.NewCommandDetonator(sshExecutor, commandToRun)
 		} else if stratusRedTeamDetonator := parsedScenario.Detonate.StratusRedTeamDetonator; stratusRedTeamDetonator != nil {
+			if stratusRedTeamDetonator.AttackTechnique == nil {
+				return nil, fmt.Errorf("scenario '%s' has a Stratus Red Team detonator with no attackTechnique defined", parsedScenario.Name)
+			}
 			scenario.Detonator = detonators.StratusRedTeamTechnique(*stratusRedTeamDetonator.AttackTechnique)
 		} else if awsCliDetonator := parsedScenario.Detonate.AwsCliDetonator; awsCliDetonator != nil {
+			if awsCliDetonator.Script == nil {
+				return nil, fmt.Errorf("scenario '%s' has an AWS CLI detonator with no script defined", parsedScenario.Name)
+			}
 			scenario.Detonator = detonators.NewAWSCLIDetonator(*awsCliDetonator.Script)
 		}
 

--- a/pkg/threatest/parser/parser_test.go
+++ b/pkg/threatest/parser/parser_test.go
@@ -5,6 +5,55 @@ import (
 	"testing"
 )
 
+// TestParserRejectsDetonatorWithMissingRequiredField ensures the parser returns
+// an error (instead of panicking with a nil pointer dereference) when a
+// detonator block is present in the YAML but its required inner field is
+// omitted.
+func TestParserRejectsDetonatorWithMissingRequiredField(t *testing.T) {
+	cases := []struct {
+		name          string
+		yamlInput     string
+		expectedError string
+	}{
+		{
+			name: "awsCliDetonator without script",
+			yamlInput: `
+scenarios:
+  - name: A
+    detonate:
+      awsCliDetonator: {}
+    expectations:
+      - timeout: 1m
+        datadogSecuritySignal:
+          name: foo
+`,
+			expectedError: "scenario 'A' has an AWS CLI detonator with no script defined",
+		},
+		{
+			name: "stratusRedTeamDetonator without attackTechnique",
+			yamlInput: `
+scenarios:
+  - name: B
+    detonate:
+      stratusRedTeamDetonator: {}
+    expectations:
+      - timeout: 1m
+        datadogSecuritySignal:
+          name: foo
+`,
+			expectedError: "scenario 'B' has a Stratus Red Team detonator with no attackTechnique defined",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scenarios, err := Parse([]byte(tc.yamlInput), "", "", "")
+			assert.Nil(t, scenarios)
+			assert.EqualError(t, err, tc.expectedError)
+		})
+	}
+}
+
 func TestParserCorrectlyParsesValidInput(t *testing.T) {
 	validYaml := `
 scenarios:


### PR DESCRIPTION
### What does this PR do?

Just a tiny improvement on error handling on missing field. This should avoid panic'ing on bad attack definition files..

### Motivation

Just doing some cleanup!

### Checklist

- [x] Unit tests
- [ ] Documentation
