### PR TITLE
Hackaround for Datadog API drift: signals no longer have a custom field

### DIFF
--- a/pkg/threatest/matchers/datadog/datadog.go
+++ b/pkg/threatest/matchers/datadog/datadog.go
@@ -158,7 +158,17 @@ func (m *DatadogAlertGeneratedAssertion) buildDatadogSignalQuery() string {
 }
 
 func (m *DatadogAlertGeneratedAssertion) signalMatchesExecution(signal datadogV2.SecurityMonitoringSignal, uid string) bool {
-	buf, _ := json.Marshal(signal.Attributes.Custom)
-	rawSignal := string(buf)
-	return strings.Contains(rawSignal, uid)
+	custom := signal.Attributes.Custom
+	// The API serializes the custom fields under the JSON key "attributes" (not "custom"),
+	// so the Go client cannot deserialize them into Custom — they land in AdditionalProperties instead.
+	// See: https://github.com/DataDog/datadog-api-client-go/issues (known issue)
+	if custom == nil {
+		if ap := signal.Attributes.AdditionalProperties; ap != nil {
+			if v, ok := ap["attributes"]; ok {
+				custom, _ = v.(map[string]interface{})
+			}
+		}
+	}
+	buf, _ := json.Marshal(custom)
+	return strings.Contains(string(buf), uid)
 }

--- a/pkg/threatest/matchers/datadog/datadog_test.go
+++ b/pkg/threatest/matchers/datadog/datadog_test.go
@@ -186,3 +186,36 @@ func TestDatadog(t *testing.T) {
 	}
 
 }
+
+func TestSignalMatchesExecution(t *testing.T) {
+	uid := "test-detonation-uid"
+	matcher := &DatadogAlertGeneratedAssertion{}
+
+	t.Run("matches when UID is in Custom (legacy path)", func(t *testing.T) {
+		signal := datadogV2.NewSecurityMonitoringSignal()
+		signal.Attributes = &datadogV2.SecurityMonitoringSignalAttributes{
+			Custom: map[string]interface{}{"foobar": uid},
+		}
+		assert.True(t, matcher.signalMatchesExecution(*signal, uid))
+	})
+
+	t.Run("matches when UID is in AdditionalProperties[attributes] (actual API response)", func(t *testing.T) {
+		signal := datadogV2.NewSecurityMonitoringSignal()
+		signal.Attributes = &datadogV2.SecurityMonitoringSignalAttributes{
+			AdditionalProperties: map[string]interface{}{
+				"attributes": map[string]interface{}{"foobar": uid},
+			},
+		}
+		assert.True(t, matcher.signalMatchesExecution(*signal, uid))
+	})
+
+	t.Run("does not match when UID is absent", func(t *testing.T) {
+		signal := datadogV2.NewSecurityMonitoringSignal()
+		signal.Attributes = &datadogV2.SecurityMonitoringSignalAttributes{
+			AdditionalProperties: map[string]interface{}{
+				"attributes": map[string]interface{}{"foobar": "other-uid"},
+			},
+		}
+		assert.False(t, matcher.signalMatchesExecution(*signal, uid))
+	})
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* Bug fix
* Enhancement
* New detonator
* New matcher
-->

Bug fix: Datadog API doesn't return an object with attributes.custom, instead there is an attributes.attributes

Until DD fixes their API, use a hack to extract the data from the `AdditionalProperties` field

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Have a working search mechanism
